### PR TITLE
Adds live-reload server.

### DIFF
--- a/koaning-blog/live-reload.py
+++ b/koaning-blog/live-reload.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from livereload import Server, shell
+from pelican import Pelican
+from pelican.settings import read_settings
+
+p = Pelican(read_settings('pelicanconf.py'))
+
+def compile():
+    try:
+        p.run()
+    except SystemExit as e:
+        pass
+
+compile()
+
+server = Server()
+server.watch('content/', compile)
+server.watch('../koaning-theme/', compile)
+server.serve(root='output')


### PR DESCRIPTION
Inspired by https://merlijn.vandeen.nl/2015/pelican-livereload.html

It uses the livereload python package (`pip install livereload`).

Running this script, e.g. `python3 live-reload.py` will use pelican to compile all sources, watch `./koaning-theme` and `./koaning-blog/content` for changes, start a webserver on localhost:5500 and inject all changes into any websocket connected browser.