### PR TITLE
Removes 404 reference to bootstrap.css.map.

### DIFF
--- a/koaning-theme/static/css/bootstrap.css
+++ b/koaning-theme/static/css/bootstrap.css
@@ -6298,4 +6298,3 @@ a.bg-danger:hover {
     display: none !important;
   }
 }
-/*# sourceMappingURL=bootstrap.css.map */


### PR DESCRIPTION
This was starting to bother me.. ;) 

![image](https://cloud.githubusercontent.com/assets/3891755/15449973/284adfcc-1f8e-11e6-8811-3ef3c8196417.png)
